### PR TITLE
CSS (ultra minor change): Remove the quote around the lobster font in…

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -48,7 +48,7 @@ h2 {
 }
 
 h1 {
-  font-family: "Lobster", "Josefin Sans", Helvetica, Arial, sans-serif;
+  font-family: Lobster, "Josefin Sans", Helvetica, Arial, sans-serif;
   font-size: 4em;
   color: #051c33;
 }


### PR DESCRIPTION
… font-family property of h1.

As lobster string do not contain white space, the quote doesn't seem necessary.

(perhaps a cosmetic choice, coloration on an ice ?)